### PR TITLE
Provide views and URLs for E2E testing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Available environment variables:
 
 * `LOGGING_LEVEL` (default: `"WARNING"`)
 * `LOGGING_HANDLERS` (default: `["stream"]`)
+* `LOGGING_FILENAME` (default: `<settings.BASE_DIR>/log/django.log`)
 
 Usage:
 
@@ -83,3 +84,68 @@ from django_utils.db.fields import TextField
 class MyModel(models.Model):
     TextField(verbose_name="My TextField")
 ```
+
+
+## Testing
+
+### Views
+
+This package provides views which can be used in E2E tests for test setup and teardown and to login or create test data.
+
+ℹ️ These views rely on the availability of a management command executable as `python manage.py load_e2e_data --datasets initial` to load initial fixture data for the tests. 
+
+⚠️ Important: Never add these views (through `django_utils.testing.urls`) in production mode! They should only be used for testing purposes.
+
+Usage:
+
+```python
+# myproject/settings/testing.py
+
+from django_utils.settings.logging import LogMixin
+
+from myproject.settings.base import Base
+
+class TestingE2E(LogMixin, Base):
+    LOGGING_LEVEL = "INFO"
+    LOGGING_HANDLERS = ["file"]
+
+    @property
+    def LOGGING_FILENAME(self):
+        return super().BASE_DIR / "log" / "e2e.log"
+
+
+# myproject/urls.py
+
+from django.conf import settings
+from django.urls import include
+from django.urls import path
+
+urlpatterns = [
+    # ...
+]
+
+if settings.CONFIGURATION == "settings.TestingE2E":
+    urlpatterns += [
+        path("e2e/", include("django_utils.testing.urls")),
+    ]
+```
+
+#### E2ETestSetupView (`/setup`)
+
+Creates a snapshot of the media root folder, resets the database and loads initial data (calls `python manage.py load_e2e_data --datasets initial`). 
+
+#### E2ETestTearDownView (`/teardown`)
+
+Cleans up the media root folder.
+
+#### TestingLoginView (`/login`)
+
+Authenticates a user when posting a JSON request body such as `{"username": "username", "password": "password"}`.
+
+#### E2ETestLoadDataView (`/load_data`)
+
+Loads given datasets using `python manage.py load_e2e_data --datasets [datasets]` when posting a JSON request body such as `{"datasets": ["initial"]}`.
+
+#### PingView (`/ping`)
+
+Responds an HTTP response with status code 200.

--- a/django_utils/settings/logging.py
+++ b/django_utils/settings/logging.py
@@ -16,6 +16,11 @@ class LogMixin:
     LOGGING_STREAM = sys.stderr
 
     @property
+    def LOGGING_FILENAME(self):
+        default_value = super().BASE_DIR / "log" / "django.log"
+        return values.Value(environ_name="LOGGING_FILENAME", default=default_value)
+
+    @property
     def LOGGING(self):
         return {
             "version": 1,
@@ -41,7 +46,7 @@ class LogMixin:
                     "level": "DEBUG",
                     "class": "logging.FileHandler",
                     "formatter": "verbose",
-                    "filename": super().BASE_DIR / "log" / "django.log",
+                    "filename": self.LOGGING_FILENAME,
                 },
                 "stream": {
                     "class": "logging.StreamHandler",

--- a/django_utils/testing/filestructure.py
+++ b/django_utils/testing/filestructure.py
@@ -1,0 +1,26 @@
+import os
+
+
+def filestructure_snapshot(path):
+    """
+    Create a filestructure snapshot by returning the paths of all files inside a path.
+    """
+    paths = []
+    for dirpath, _dirnames, filenames in os.walk(path):
+        paths.append(dirpath)
+        for filename in filenames:
+            paths.append(os.path.join(dirpath, filename))
+    return paths
+
+
+def cleanup_path(path, snapshot_before):
+    """
+    Remove all files and directories inside a path which did not exist in the snapshot_before.
+    """
+    snapshot_after = filestructure_snapshot(path)
+    to_delete = reversed(sorted(set(snapshot_after) - set(snapshot_before)))
+    for path in to_delete:
+        if os.path.isfile(path):
+            os.unlink(path)
+        if os.path.isdir(path):
+            os.removedirs(path)

--- a/django_utils/testing/urls.py
+++ b/django_utils/testing/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+
+from django_utils.testing import views
+
+urlpatterns = [
+    path("setup", views.E2ETestSetupView.as_view()),
+    path("teardown", views.E2ETestTearDownView.as_view()),
+    path("login", views.TestingLoginView.as_view()),
+    path("load_data", views.E2ETestLoadDataView.as_view()),
+    path("ping", views.PingView.as_view()),
+]

--- a/django_utils/testing/views.py
+++ b/django_utils/testing/views.py
@@ -1,0 +1,95 @@
+import json
+import logging
+
+from django.conf import settings
+from django.contrib.auth import authenticate
+from django.contrib.auth import login
+from django.core.management import call_command
+from django.db import connection
+from django.http import HttpResponse
+from django.utils.decorators import method_decorator
+from django.views import View
+from django.views.decorators.csrf import csrf_exempt
+
+from django_utils.testing.filestructure import cleanup_path
+from django_utils.testing.filestructure import filestructure_snapshot
+
+logger = logging.getLogger(__name__)
+
+SNAPSHOT_BEFORE = []
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class E2ETestSetupView(View):
+    def reset_database(self):
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                DO
+                $func$
+                BEGIN
+                EXECUTE
+                (SELECT 'TRUNCATE TABLE ' || string_agg(oid::regclass::text, ', ') || ' RESTART IDENTITY'
+                    FROM   pg_class
+                    WHERE  relkind = 'r'  -- only tables
+                    AND    relnamespace = 'public'::regnamespace
+                );
+                END
+                $func$;
+                """
+            )
+
+    def load_initial_data(self):
+        call_command("load_e2e_data", datasets=["initial"])
+
+    def post(self, request, *args, **kwargs):
+        logger.info("E2E test setup")
+
+        # Create a snapshot of the media root folder before the test
+        SNAPSHOT_BEFORE.extend(filestructure_snapshot(settings.MEDIA_ROOT))
+
+        self.reset_database()
+        self.load_initial_data()
+
+        return HttpResponse(status=200)
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class E2ETestTearDownView(View):
+    def post(self, request, *args, **kwargs):
+        logger.info("E2E test teardown")
+
+        # Cleanup the media root folder by removing any files added since the snapshot in the
+        # `E2ETestSetupView`.
+        cleanup_path(settings.MEDIA_ROOT, SNAPSHOT_BEFORE)
+        SNAPSHOT_BEFORE.clear()
+
+        return HttpResponse(status=200)
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class TestingLoginView(View):
+    def post(self, request):
+        data = json.loads(request.body)
+        username = data.get("username", "username")
+        password = data.get("password", "password")
+        user = authenticate(request, username=username, password=password)
+        if user and user.is_authenticated:
+            login(request, user)
+            return HttpResponse(status=200)
+        return HttpResponse(status=401)
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class E2ETestLoadDataView(View):
+    def post(self, request, *args, **kwargs):
+        data = json.loads(request.body)
+        datasets = data.get("datasets")
+        logger.info(f"E2E loading datasets {datasets}")
+        call_command("load_e2e_data", datasets=datasets)
+        return HttpResponse(status=200)
+
+
+class PingView(View):
+    def head(self, request, *args, **kwargs):
+        return HttpResponse("pong", status=200)


### PR DESCRIPTION
Unfortunately, there are no tests yet.

Also, I do not like the fact that it relies on the management command `load_e2e_data` which has to be implemented outside of this package but is very specific on how it has to be written. A much nicer approach would be to kind of register e2e test fixtures in the application and load them through a management command inside of this django-utils package...