### PR TITLE
Allow specification of SENTRY_TAGS through env variable.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+Unreleased
+----------
+
+- Allow specification of `SENTRY_TAGS` through an environment variable.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Available environment variables:
 * `SENTRY_DSN` (required)
 * `SENTRY_ENVIRONMENT` (default: `"Production"`)
 * `SENTRY_CACERTS` (default: `None`)
+* `SENTRY_TAGS` (default: `{}`)
 
 Usage:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # django-utils
 A collection of utils used in our Django based web applications
 
+[Changelog](CHANGELOG.rst)
 
 ## Settings
 

--- a/django_utils/settings/sentry.py
+++ b/django_utils/settings/sentry.py
@@ -11,7 +11,7 @@ class SentryMixin:
     # A path to an alternative CA bundle file in PEM-format.
     SENTRY_CACERTS = values.Value(None, environ_prefix="")
 
-    SENTRY_TAGS = {}
+    SENTRY_TAGS = values.DictValue(default={}, environ_prefix="")
 
     @classmethod
     def post_setup(cls):


### PR DESCRIPTION
The `SentryMixin` now allows to set the `SENTRY_TAGS` through an environment variable.