### PR TITLE
Fix django deprication-warning

### DIFF
--- a/django_utils/__init__.py
+++ b/django_utils/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "django_utils.apps.DjangoUtilsAppConfig"


### PR DESCRIPTION
The warning was:
RemovedInDjango41Warning: 'django_utils' defines default_app_config = 'django_utils.apps.DjangoUtilsAppConfig'. Django now detects this configuration automatically.