### PR TITLE
Use more lax Python version specifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
-    python_requires=">=3.6.*, <4",
+    python_requires=">=3.6, <4",
     install_requires=[
         "django-configurations",
         "django-extensions",


### PR DESCRIPTION
Since a recent update, tests for some products using django-utils suddenly failed on our CI with the following error message:

error in django-utils setup command: 'python_requires' must be a string containing valid version specifiers; Invalid specifier: '>=3.6.*'

This can be fixed by using a more lax specifier.