### PR TITLE
No longer depend on a specific Django major version.

### DIFF
--- a/changes/django-x.other
+++ b/changes/django-x.other
@@ -1,0 +1,1 @@
+No longer depend on specific Django major version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ django-configurations = "^2.4.1"
 django-extensions = "^3.2.1"
 sentry-sdk = "^1.21.0"
 djangorestframework = "^3"
-django = "^3"
+django = "*"
 django-sendfile2 = "^0.7.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
This way, we are compatible with Django 4.x (e.g. LTS 4.2). Unfortunately, we do not have testing for this package, so we will have to try and find out whether we are encountering any incompatibilities.

- Changelog: ✅ 
- Testing: 🤔 
- README.md: -
