### PR TITLE
Make sentry init more configurable

### DIFF
--- a/changes/HG-3984.other
+++ b/changes/HG-3984.other
@@ -1,0 +1,1 @@
+Provide additional default sentry arguments and allow overriding them more easily.

--- a/django_utils/settings/sentry.py
+++ b/django_utils/settings/sentry.py
@@ -6,25 +6,58 @@ from sentry_sdk.integrations.django import DjangoIntegration
 class SentryMixin:
     SENTRY_DSN = values.Value(environ_required=True, environ_prefix="")
 
-    SENTRY_ENVIRONMENT = values.Value("Production", environ_prefix="")
-
     # A path to an alternative CA bundle file in PEM-format.
     SENTRY_CACERTS = values.Value(None, environ_prefix="")
 
     SENTRY_TAGS = values.DictValue(default={}, environ_prefix="")
+    SENTRY_ENVIRONMENT = values.Value("Production", environ_prefix="")
+    SENTRY_SERVER_NAME = values.Value(None, environ_prefix="")
+    SENTRY_IN_APP_INLCUDE = values.ListValue(default=[], environ_prefix="")
+    SENTRY_IN_APP_EXCLUDE = values.ListValue(default=[], environ_prefix="")
 
     @classmethod
     def post_setup(cls):
         super().post_setup()
-        if cls.SENTRY_DSN is not None:
-            sentry_sdk.init(
-                dsn=cls.SENTRY_DSN,
-                integrations=[DjangoIntegration()],
-                send_default_pii=True,
-                environment=cls.SENTRY_ENVIRONMENT,
-                ca_certs=cls.SENTRY_CACERTS,
-            )
+        cls.init_sentry_sdk()
+        cls.configure_sentry_tags()
 
-        if cls.SENTRY_TAGS:
-            for tagname, tagvalue in cls.SENTRY_TAGS.items():
-                sentry_sdk.set_tag(tagname, tagvalue)
+    @classmethod
+    def init_sentry_sdk(cls):
+        if cls.SENTRY_DSN is None:
+            return
+
+        sentry_sdk.init(**cls.make_sentry_init_kwargs())
+
+    @classmethod
+    def make_sentry_init_kwargs(cls):
+        return dict(
+            dsn=cls.SENTRY_DSN,
+            integrations=[DjangoIntegration()],
+            send_default_pii=True,
+            environment=cls.get_sentry_environment(),
+            ca_certs=cls.SENTRY_CACERTS,
+            release=cls.get_sentry_release_version(),
+            server_name=cls.SENTRY_SERVER_NAME,
+            in_app_include=cls.SENTRY_IN_APP_INLCUDE,
+            in_app_exclude=cls.SENTRY_IN_APP_EXCLUDE,
+        )
+
+    @classmethod
+    def get_sentry_environment(cls):
+        return cls.SENTRY_ENVIRONMENT
+
+    @classmethod
+    def get_sentry_release_version(cls):
+        return None
+
+    @classmethod
+    def get_sentry_tags(cls):
+        return cls.SENTRY_TAGS
+
+    @classmethod
+    def configure_sentry_tags(cls):
+        if cls.SENTRY_DSN is None:
+            return
+
+        for tagname, tagvalue in cls.get_sentry_tags().items():
+            sentry_sdk.set_tag(tagname, tagvalue)


### PR DESCRIPTION
- Provide some more defaults values
- Allow to override default easily with dynamic values from factory methods
- Unfortunately this seems necessary as overriding them with an `@property` does not work correctly when the attributes are accessed without an instance of the class, e.g. inside `@classmethod`
- Provide option to override init kwargs

Overrides can be seen in https://github.com/4teamwork/ris/pull/3236/files

- Changelog: ✅ 
- Testing: 🤷 
- README.md: ❌ 
